### PR TITLE
Bug fix

### DIFF
--- a/python/primes.py
+++ b/python/primes.py
@@ -5,13 +5,15 @@ def primes(num: int) -> List[int]:
     is_primes = [True] * (num + 1)
     is_primes[0] = is_primes[1] = False
 
-    for i in range(2, int(sqrt(num)) + 1):
+    # k が素数かどうかは sqrt(k) より小さい素数で割り算すれば良い
+    # それらの素数で割れなければ素数
+    # ref: https://manabitimes.jp/math/992
+    for i in range(2, int(sqrt(num))):
         if not is_primes[i]:
             continue
         for j in range(i * 2, num + 1, i):
             is_primes[j] = False
     return [i for i in range(num + 1) if is_primes[i]] 
-
 
 if __name__ == '__main__':
     num = 101


### PR DESCRIPTION

sqrt(n) より小さい素数で割り算すれば良い。
range(..) stop 引数の +1 は不要
https://github.com/kharigai/algorithm/blob/d22139a430cff095598c4ea31f9e5d7cecc8d4ab/python/primes.py#L8

## 資料

- [エラトステネスのふるいとその計算量](https://manabitimes.jp/math/992)